### PR TITLE
Resolved Ambiguous reference between Microsoft.AspNetCore.Mvc.ViewFeatures.InputType and MudBlazor.InputType

### DIFF
--- a/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Login.razor
+++ b/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Login.razor
@@ -1,5 +1,7 @@
 ﻿@page "/"
 @page "/pages/authentication/login"
+
+@using InputType = MudBlazor.InputType
 @layout LoginLayout
 
 

--- a/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Register.razor
+++ b/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Register.razor
@@ -1,4 +1,6 @@
 ﻿@page "/pages/authentication/register"
+
+@using InputType = MudBlazor.InputType
 @layout LoginLayout
 
 

--- a/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Reset.razor
+++ b/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Reset.razor
@@ -1,4 +1,6 @@
 ﻿@page "/pages/authentication/reset-password"
+
+@using InputType = MudBlazor.InputType
 @layout LoginLayout
 
 


### PR DESCRIPTION
Hello all,

I have been using MudBlazor quite a bit, I usually start from the very nicely provided `dotnet new` templates by the MudBlazor team.

I have found that every time I use the templates, I receive an error saying:

`Ambiguous reference between Microsoft.AspNetCore.Mvc.ViewFeatures.InputType and MudBlazor.InputType`

See my screenshot for reference:

![image](https://user-images.githubusercontent.com/12589359/139008696-153edcea-0da5-4a25-84af-ea32e62f628d.png)


This occurs in the following files in the **ADMIN DASHBOARD** template:

* [Login.razor](https://github.com/MudBlazor/Templates/blob/dev/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Login.razor)
* [Register.razor](https://github.com/MudBlazor/Templates/blob/dev/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Register.razor)
* [Reset.razor](https://github.com/MudBlazor/Templates/blob/dev/src/.template.mudblazor/admindashboard/Pages/Pages/Authentication/Reset.razor)

I have simply added this code to resolve the ambiguous reference error before it happens:

`@using InputType = MudBlazor.InputType`

See Screenshot: 
![image](https://user-images.githubusercontent.com/12589359/139009014-b83302b1-b801-45ff-80ad-215a74328497.png)


-------

Hopefully this small fix is helpful! 
Love the library! I plan to continue to submit pull requests to improve the great and epic MudBlazor!
