### PR TITLE
Use relative not absolute paths

### DIFF
--- a/src/.template.mudblazor/defaultblazor/Shared/NavMenu.razor
+++ b/src/.template.mudblazor/defaultblazor/Shared/NavMenu.razor
@@ -1,5 +1,5 @@
 ﻿<MudNavMenu>
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    <MudNavLink Href="/counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
-    <MudNavLink Href="/fetchdata" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Fetch data</MudNavLink>
+    <MudNavLink Href="counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
+    <MudNavLink Href="fetchdata" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Fetch data</MudNavLink>
 </MudNavMenu>


### PR DESCRIPTION
In the nav menu we are currently using absolute paths for the counter and fetch data links.

This breaks if the app is not hosted on the route and is contrary to the default dotnet blazor templates which uses the relative paths.