### PR TITLE
Squash those pesky null reference warnings.

### DIFF
--- a/src/.template.mudblazor/defaultblazor/Pages/FetchData.razor
+++ b/src/.template.mudblazor/defaultblazor/Pages/FetchData.razor
@@ -24,7 +24,7 @@ else
             <MudTh><MudTableSortLabel InitialDirection="SortDirection.Ascending" SortBy="new Func<WeatherForecast, object>(x=>x.Date)">Date</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<WeatherForecast, object>(x=>x.TemperatureC)">Temp. (C)</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<WeatherForecast, object>(x=>x.TemperatureF)">Temp. (F)</MudTableSortLabel></MudTh>
-            <MudTh><MudTableSortLabel SortBy="new Func<WeatherForecast, object>(x=>x.Summary)">Summary</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel SortBy="new Func<WeatherForecast, object>(x=>x.Summary!)">Summary</MudTableSortLabel></MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Date">@context.Date</MudTd>
@@ -40,7 +40,7 @@ else
 
 
 @code {
-    private WeatherForecast[] forecasts;
+    private WeatherForecast[]? forecasts;
 
     protected override async Task OnInitializedAsync()
     {
@@ -59,7 +59,7 @@ else
 
         public int TemperatureC { get; set; }
 
-        public string Summary { get; set; }
+        public string? Summary { get; set; }
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
     }


### PR DESCRIPTION
Compiler throws null reference warnings on build, this cleans up the output.

![Screenshot_20220322_171136](https://user-images.githubusercontent.com/1404606/159516123-b210655d-4a63-414b-b71e-481e0054f07d.png)

See C# documentation at: [Nullable reference types](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-variable-annotations)
